### PR TITLE
쿼리 로깅 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
     runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'
     compile('com.h2database:h2')

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     }
 
     compile group: 'com.auth0', name: 'java-jwt', version: '3.7.0'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml'
     compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.714'
     compile "io.springfox:springfox-swagger2:2.9.2"
     compile "io.springfox:springfox-swagger-ui:2.9.2"


### PR DESCRIPTION
- p6spy 라이브러리 통해서 쿼리 로깅하는 부분 제거
- `jackson-dataformat-xml` 사용하지 않는 라이브러리 제거