### PR TITLE
refactor: 필요하지 않은 의존성 제거

### DIFF
--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
     implementation group: 'com.auth0', name: 'java-jwt', version: '3.7.0'
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.714'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.714'
 }
 
 test {


### PR DESCRIPTION
## AS-IS
- AWS 전체 서비스의 SDK 에 모두 의존하고 있음

## TO-BE
- 사용중인 서비스에만 의존함 (AWS S3)
- jar 파일 용량 148 MB 감소 (201MB -> 53MB)