### PR TITLE
로그인 토큰 검증 코드리뷰 내용 반영

### DIFF
--- a/interfaces/src/main/java/com/depromeet/team5/application/security/TokenVerifier.java
+++ b/interfaces/src/main/java/com/depromeet/team5/application/security/TokenVerifier.java
@@ -1,0 +1,6 @@
+package com.depromeet.team5.application.security;
+
+public interface TokenVerifier {
+
+    boolean isVerified(String accessToken);
+}

--- a/interfaces/src/main/java/com/depromeet/team5/application/user/UserApplicationService.java
+++ b/interfaces/src/main/java/com/depromeet/team5/application/user/UserApplicationService.java
@@ -30,7 +30,11 @@ public class UserApplicationService {
         SocialType socialType = socialVo.getSocialType();
         String token = socialVo.getToken();
 
-        if (token != null && !isValid(socialType, token)) {
+        /**
+         * 원래는 모든 로그인 토큰의 유효성을 검증해야하나,
+         * 하위호환성 유지를 위해 토큰이 있는 경우에만 검증을 진행합니다.
+         */
+        if (token != null && !isVerified(socialType, token)) {
             throw new InvalidAccessTokenException();
         }
 
@@ -45,7 +49,7 @@ public class UserApplicationService {
         return userAssembler.toUserResponse(user);
     }
 
-    private boolean isValid(SocialType socialType, String token) {
+    private boolean isVerified(SocialType socialType, String token) {
 
         if (Objects.equals(socialType, SocialType.KAKAO)) {
             return kakaoLoginTokenVerifier.isVerified(token);

--- a/interfaces/src/main/java/com/depromeet/team5/application/user/UserApplicationService.java
+++ b/interfaces/src/main/java/com/depromeet/team5/application/user/UserApplicationService.java
@@ -4,8 +4,8 @@ import com.depromeet.team5.domain.user.SocialType;
 import com.depromeet.team5.domain.user.SocialVo;
 import com.depromeet.team5.dto.LoginResponse;
 import com.depromeet.team5.exception.InvalidAccessTokenException;
-import com.depromeet.team5.infrastructure.apple.AppleLoginTokenValidator;
-import com.depromeet.team5.infrastructure.kakao.KakaoLoginTokenValidator;
+import com.depromeet.team5.infrastructure.apple.AppleLoginTokenVerifier;
+import com.depromeet.team5.infrastructure.kakao.KakaoLoginTokenVerifier;
 import com.depromeet.team5.domain.user.User;
 import com.depromeet.team5.dto.UserResponse;
 import com.depromeet.team5.service.UserService;
@@ -21,20 +21,16 @@ public class UserApplicationService {
 
     private final UserService userService;
     private final UserAssembler userAssembler;
-    private final KakaoLoginTokenValidator kakaoLoginTokenValidator;
-    private final AppleLoginTokenValidator appleLoginTokenValidator;
+    private final KakaoLoginTokenVerifier kakaoLoginTokenVerifier;
+    private final AppleLoginTokenVerifier appleLoginTokenVerifier;
 
     @Transactional
     public LoginResponse login(SocialVo socialVo) {
 
-        boolean isValid = true;
         SocialType socialType = socialVo.getSocialType();
         String token = socialVo.getToken();
 
-        if (token != null) {
-            isValid = checkLoginToken(socialType, token);
-        }
-        if (!isValid) {
+        if (token != null && !isValid(socialType, token)) {
             throw new InvalidAccessTokenException();
         }
 
@@ -49,12 +45,12 @@ public class UserApplicationService {
         return userAssembler.toUserResponse(user);
     }
 
-    private boolean checkLoginToken(SocialType socialType, String token) {
+    private boolean isValid(SocialType socialType, String token) {
 
         if (Objects.equals(socialType, SocialType.KAKAO)) {
-            return kakaoLoginTokenValidator.isValid(token);
+            return kakaoLoginTokenVerifier.isVerified(token);
         } else if (Objects.equals(socialType, SocialType.APPLE)) {
-            return appleLoginTokenValidator.isValid(token);
+            return appleLoginTokenVerifier.isVerified(token);
         }
 
         return false;

--- a/interfaces/src/main/java/com/depromeet/team5/infrastructure/apple/AppleLoginTokenVerifier.java
+++ b/interfaces/src/main/java/com/depromeet/team5/infrastructure/apple/AppleLoginTokenVerifier.java
@@ -1,6 +1,7 @@
 package com.depromeet.team5.infrastructure.apple;
 
 import com.depromeet.team5.application.security.TokenValidator;
+import com.depromeet.team5.application.security.TokenVerifier;
 import com.depromeet.team5.exception.FailedToParseJwtException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +27,7 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AppleLoginTokenValidator implements TokenValidator {
+public class AppleLoginTokenVerifier implements TokenVerifier {
 
     @Value("${apple.base_url")
     private String appleBaseUrl;
@@ -75,12 +76,7 @@ public class AppleLoginTokenValidator implements TokenValidator {
     }
 
     @Override
-    public boolean supports(String accessToken) {
-        return false;
-    }
-
-    @Override
-    public boolean isValid(String accessToken) {
+    public boolean isVerified(String accessToken) {
         Claims claim = getClaims(accessToken);
         return claim != null
                 && appleBaseUrl.equals(claim.getIssuer())

--- a/interfaces/src/main/java/com/depromeet/team5/infrastructure/kakao/KakaoLoginTokenVerifier.java
+++ b/interfaces/src/main/java/com/depromeet/team5/infrastructure/kakao/KakaoLoginTokenVerifier.java
@@ -1,6 +1,7 @@
 package com.depromeet.team5.infrastructure.kakao;
 
 import com.depromeet.team5.application.security.TokenValidator;
+import com.depromeet.team5.application.security.TokenVerifier;
 import com.google.common.net.HttpHeaders;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,17 +12,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KakaoLoginTokenValidator implements TokenValidator {
+public class KakaoLoginTokenVerifier implements TokenVerifier {
 
     private final WebClient webClient;
 
     @Override
-    public boolean supports(String accessToken) {
-        return false;
-    }
-
-    @Override
-    public boolean isValid(String accessToken) {
+    public boolean isVerified(String accessToken) {
 
         ClientResponse clientResponse = webClient.mutate()
                  .baseUrl("https://kapi.kakao.com")


### PR DESCRIPTION
### 커밋 상세
- 가변 변수이던 isValid 변수 대신 메소드의 리턴값을 사용하여 조건 검증
- login token validator들을 TokenVerifier를 구현하도록 변경

### 설명
- validator를 일단 구현하지 않도록 변경한 후, validator를 구현하지 않으므로 모듈의 이름도 변경했습니다.
- 추후에 구글 등 다른 SNS 로그인 모듈이 생성될 수 있으므로 이전에 삭제했던 TokenVerifier 인터페이스를 다시 생성해 해당 인터페이스를 구현하도록 했습니다.